### PR TITLE
Fix Error When Adding Duplicate Podcast

### DIFF
--- a/API/src/accessors/supabase/UserPodcast.ts
+++ b/API/src/accessors/supabase/UserPodcast.ts
@@ -13,7 +13,7 @@ export async function Get(
   const { data, error } = await supabaseClient
     .from("UserPodcast")
     .select()
-    .eq("id", UserId)
+    .eq("user_id", UserId)
     .eq("podcast_id", PodcastId)
     .single();
 

--- a/API/src/services/Podcast.ts
+++ b/API/src/services/Podcast.ts
@@ -72,14 +72,17 @@ export async function UpdateUserPodcast(
   if (newPodcast) {
     // New podcast so must add
     await user_podcast_db.Add(UserId, podcastId as number, new Date(), true);
-  } else {
+  } 
+  else {
     const userPodcastResult = await user_podcast_db.Get(
       UserId,
       podcastId as number,
     );
+
     if (!userPodcastResult) {
       await user_podcast_db.Add(UserId, podcastId as number, new Date(), true);
-    } else if (userPodcastResult.is_active != IsActive) {
+    } 
+    else if (userPodcastResult.is_active != IsActive) {
       // If podcast active status does not match incoming param, update
       await user_podcast_db.SetActive(userPodcastResult.id, IsActive);
     }


### PR DESCRIPTION
Adding a duplicate podcast would cause a 500 error because the `user_id` on the db query was referencing the wrong column. 